### PR TITLE
fix: use tcpSocket for grpc healtchecks

### DIFF
--- a/charts/coop-app-chart/templates/deployment.yaml
+++ b/charts/coop-app-chart/templates/deployment.yaml
@@ -81,7 +81,8 @@ spec:
             {{- if .Values.health.livenessProbe -}}
             {{ .Values.health.livenessProbe | toYaml | nindent 12}}
             {{- else if .Values.connectivity.gRPC.enabled }}
-            grpc:
+            # istio 1.10.2 does not support grpc health, fallback to tcp for now
+            tcpSocket:
               port: {{ .Values.port }}
             {{- else }} 
             httpGet:
@@ -92,7 +93,8 @@ spec:
             {{- if .Values.health.readynessProbe -}}
             {{ .Values.health.readinessProbe | toYaml | nindent 12}}
             {{- else if .Values.connectivity.gRPC.enabled }}
-            grpc:
+            # istio 1.10.2 does not support grpc health, fallback to tcp for now
+            tcpSocket:
               port: {{ .Values.port }}
             {{- else }} 
             httpGet:


### PR DESCRIPTION
earliest version of istio that supports grpc healthcheck is 1.13

https://github.com/istio/istio/commit/7c6403332f5044f78d8f541ce983066c8357bd90