### PR TITLE
fix: Trigger version updater on `created` and `edited` instead of `published`

### DIFF
--- a/.github/workflows/helm-chart-version-updater.yaml
+++ b/.github/workflows/helm-chart-version-updater.yaml
@@ -2,7 +2,7 @@ name: Auto-update chart version
 
 on:
   release:
-    types: [ published ]
+    types: [ created, edited ]
 
 jobs:
   get-release-details:


### PR DESCRIPTION
related to: https://github.com/coopnorge/cloud-platform-team/issues/894