### PR TITLE
fix: Remove github-review-bot from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,3 @@
 /CODEOWNERS @coopnorge/cloud-security
 
 .github/workflows/security-* @coopnorge/cloud-security
-
-/charts/coop-app-chart/Chart.yaml @coopnorge/github-review-bots


### PR DESCRIPTION
Since we will no longer use version update PRs, this is no longer relevant.

It is blocking this from being merged: https://github.com/coopnorge/helm-base-chart/pull/25