### PR TITLE
feat: create workflow that updates the dependency in consumers

### DIFF
--- a/.github/workflows/update-chart-reusable-workflow.yaml
+++ b/.github/workflows/update-chart-reusable-workflow.yaml
@@ -1,0 +1,31 @@
+---
+name: Update Helm Charts that use coop-app-chart
+on:
+  workflow_call:
+    inputs:
+      chart-dir:
+        required: true
+        type: string
+        description: |
+          Directory of the helm chart. Should contain a Chart.yaml with this dependency
+
+jobs:
+  update-coop-app-chart:
+    name: Update Coop App Chart Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Update Chart version
+        run: |
+          v=${{steps.dependabot-metadata.outputs.new-version}} yq -i '(.dependencies[]|select(.name="coop-app-chart").version ) = strenv(v)' Chart.yaml
+        working-directory: ${{ input.chart-dir }}
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Update helm chart dependency coop-app-chart to ${{steps.dependabot-metadata.outputs.new-version}}
+     
+


### PR DESCRIPTION
This could be an interesting hack to update libraries which are not supported by dependabot. 

The idea is this:
* We publish a release with version X
* The reusable workflow is also updated to version X

The consumer of the library 
* has this workflow and gets a dependabot update to update the workflow
* the workflow will then update the pr created by dependabot with the version update.

Upsides
* updates get in via dependabot
* get dependabot pr features for free (autoclosing/rebase etc)
* get the release notes in the pr

Downsides:
* its a bit dirty
* PR name might be a bit misleading

For safety reasons it is important that the consumer of the workflow only triggers on the right file patterns. 

