### PR TITLE
fix: Get release tag another way

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -25,9 +25,9 @@ jobs:
       - name: Get release version
         id: get_release_version
         run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          echo "release_tag=$TAG" >> $GITHUB_OUTPUT
-          echo "release_version=${TAG#v}" >> $GITHUB_OUTPUT
+          TAG="${{ github.event.release.tag_name }}"
+          echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "release_version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Install Helm
         uses: azure/setup-helm@v3


### PR DESCRIPTION
It's unclear why this is not working: https://github.com/coopnorge/helm-base-chart/actions/runs/6875640798/job/18779468827

So, trying out a different way to get release tag.