### PR TITLE
feat: truncate port-name to 15 characters

### DIFF
--- a/charts/coop-app-chart/templates/_helpers.tpl
+++ b/charts/coop-app-chart/templates/_helpers.tpl
@@ -56,9 +56,12 @@ app.kubernetes.io/name: {{ include "coop-app-chart.name" . }}
 Port-naming
 */}}
 {{- define "coop-app-chart.portName" -}}
+{{- $name := .Values.name -}}
 {{- if .Values.connectivity.gRPC.enabled -}}
-grpc-{{ .Values.name }}
-{{- else -}}
-{{ .Values.name }}
+{{- $name = print "grpc-" $name -}}
 {{- end }}
+{{- if gt (len $name) 15 -}}
+{{- $name = substr 0 15 $name -}}
+{{- end -}}
+{{ $name }}
 {{- end }}


### PR DESCRIPTION
When trying to deploy `price-information-service` in `price-data`
argoCD sync status shows that `Deployment` failed stating:

```
Deployment.apps "price-information-service" is invalid:
spec.template.spec.containers[0].ports[0].name:
Invalid value: "grpc-price-information-service": must be no more than 15 characters
```

This change makes sure, that the port name is always truncated to
15 character if it is greater than 15 characters.

Tradeoff: Port-name collision might occur if 15 characters of port
between two services in the same namespace matches.
