### PR TITLE
feat!: use standard image format

### DIFF
--- a/charts/coop-app-chart/templates/_helpers.tpl
+++ b/charts/coop-app-chart/templates/_helpers.tpl
@@ -30,7 +30,7 @@ Pod labels
 {{ include "coop-app-chart.selectorLabels" . }}
 tags.datadoghq.com/env: {{ .Values.environment }}
 tags.datadoghq.com/service: {{ .Values.name }}
-tags.datadhoghq.com/version: {{ .Values.image.tag }}
+tags.datadoghq.com/version: {{ .Values.image.tag }}
 {{- end }}
 
 {{/*:
@@ -41,7 +41,7 @@ helm.sh/chart: {{ include "coop-app-chart.chart" . }}
 {{ include "coop-app-chart.selectorLabels" . }}
 tags.datadoghq.com/env: {{ .Values.environment }}
 tags.datadoghq.com/service: {{ .Values.name }}
-tags.datadhoghq.com/version: {{ .Values.image.tag }}
+tags.datadoghq.com/version: {{ .Values.image.tag }}
 {{- end }}
 
 

--- a/charts/coop-app-chart/templates/_helpers.tpl
+++ b/charts/coop-app-chart/templates/_helpers.tpl
@@ -30,7 +30,7 @@ Pod labels
 {{ include "coop-app-chart.selectorLabels" . }}
 tags.datadoghq.com/env: {{ .Values.environment }}
 tags.datadoghq.com/service: {{ .Values.name }}
-tags.datadhoghq.com/version: {{ last (splitList ":" .Values.image.tag) }}
+tags.datadhoghq.com/version: {{ .Values.image.tag }}
 {{- end }}
 
 {{/*:
@@ -41,7 +41,7 @@ helm.sh/chart: {{ include "coop-app-chart.chart" . }}
 {{ include "coop-app-chart.selectorLabels" . }}
 tags.datadoghq.com/env: {{ .Values.environment }}
 tags.datadoghq.com/service: {{ .Values.name }}
-tags.datadhoghq.com/version: {{ last (splitList ":" .Values.image.tag) }}
+tags.datadhoghq.com/version: {{ .Values.image.tag }}
 {{- end }}
 
 

--- a/charts/coop-app-chart/templates/_helpers.tpl
+++ b/charts/coop-app-chart/templates/_helpers.tpl
@@ -30,7 +30,7 @@ Pod labels
 {{ include "coop-app-chart.selectorLabels" . }}
 tags.datadoghq.com/env: {{ .Values.environment }}
 tags.datadoghq.com/service: {{ .Values.name }}
-tags.datadhoghq.com/version: {{ last (splitList ":" .Values.image) }}
+tags.datadhoghq.com/version: {{ last (splitList ":" .Values.image.tag) }}
 {{- end }}
 
 {{/*:
@@ -41,7 +41,7 @@ helm.sh/chart: {{ include "coop-app-chart.chart" . }}
 {{ include "coop-app-chart.selectorLabels" . }}
 tags.datadoghq.com/env: {{ .Values.environment }}
 tags.datadoghq.com/service: {{ .Values.name }}
-tags.datadhoghq.com/version: {{ last (splitList ":" .Values.image) }}
+tags.datadhoghq.com/version: {{ last (splitList ":" .Values.image.tag) }}
 {{- end }}
 
 

--- a/charts/coop-app-chart/templates/deployment.yaml
+++ b/charts/coop-app-chart/templates/deployment.yaml
@@ -27,8 +27,8 @@ spec:
         - name: {{ .Values.name }}
           securityContext:
             {{- toYaml .Values.advanced.deployment.securityContext | nindent 12 }}
-          image: "{{ .Values.image }}"
-          imagePullPolicy: Always
+          image: "{{ required "A valid .Values.image.repository is required!" .Values.image.repository }}:{{ required "A valid .Values.image.tag is required!" .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           env: 
             - name: DD_DOGSTATSD_URL
               value: "unix:///var/run/datadog/dsd.socket"

--- a/charts/coop-app-chart/templates/deployment.yaml
+++ b/charts/coop-app-chart/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           securityContext:
             {{- toYaml .Values.advanced.deployment.securityContext | nindent 12 }}
           image: "{{ .Values.image.registry }}/{{ required "A valid .Values.image.repository is required!" .Values.image.repository }}:{{ required "A valid .Values.image.tag is required!" .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
+          imagePullPolicy: Always
           env: 
             - name: DD_DOGSTATSD_URL
               value: "unix:///var/run/datadog/dsd.socket"

--- a/charts/coop-app-chart/templates/deployment.yaml
+++ b/charts/coop-app-chart/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: {{ .Values.name }}
           securityContext:
             {{- toYaml .Values.advanced.deployment.securityContext | nindent 12 }}
-          image: "{{ required "A valid .Values.image.repository is required!" .Values.image.repository }}:{{ required "A valid .Values.image.tag is required!" .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ required "A valid .Values.image.repository is required!" .Values.image.repository }}:{{ required "A valid .Values.image.tag is required!" .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           env: 
             - name: DD_DOGSTATSD_URL

--- a/charts/coop-app-chart/values.yaml
+++ b/charts/coop-app-chart/values.yaml
@@ -5,6 +5,7 @@ environment: # environment to which you deploy for ex production or staging
 image:
   repository: # the repository where the image is stored
   tag: # the tag of the image
+  registry: europe-docker.pkg.dev # the registry where the image is stored
   pullPolicy: Always # the policy to pull the image
   
 port: # the port on which the service is going to run

--- a/charts/coop-app-chart/values.yaml
+++ b/charts/coop-app-chart/values.yaml
@@ -2,7 +2,11 @@ name: # the name of the service
 
 environment: # environment to which you deploy for ex production or staging
 
-image: # full image url of your image
+image:
+  repository: # the repository where the image is stored
+  tag: # the tag of the image
+  pullPolicy: Always # the policy to pull the image
+  
 port: # the port on which the service is going to run
 
 environmentVariables: {}

--- a/charts/coop-app-chart/values.yaml
+++ b/charts/coop-app-chart/values.yaml
@@ -6,7 +6,6 @@ image:
   repository: # the repository where the image is stored
   tag: # the tag of the image
   registry: europe-docker.pkg.dev # the registry where the image is stored
-  pullPolicy: Always # the policy to pull the image
   
 port: # the port on which the service is going to run
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,9 @@ We take an gRPC service as an example setup. Edit `values.yaml`
 app: # app key related to the alias defined in the dependencies.
   name: helloworld
   
-  image: path-to-repo/helloworld:v1.2.9999
+  image: 
+    repository: path-to-repo/helloworld
+    tag: v1.2.9999
   port: 3000
   
   environmentVariables:

--- a/examples/addons/values.yaml
+++ b/examples/addons/values.yaml
@@ -5,7 +5,9 @@ app:
   
   environment: production
   
-  image: path-to-repo/helloworld:v1.2.9999
+  image: 
+    repository: path-to-repo/helloworld
+    tag: v1.2.9999
   port: 3000
   
   environmentVariables:

--- a/examples/grpc/values.yaml
+++ b/examples/grpc/values.yaml
@@ -5,7 +5,9 @@ app:
   
   environment: production
   
-  image: path-to-repo/helloworld:v1.2.9999
+  image:
+    repository: path-to-repo/helloworld
+    tag: v1.2.9999
   port: 3000
   
   environmentVariables:

--- a/examples/http/values.yaml
+++ b/examples/http/values.yaml
@@ -6,7 +6,9 @@ app:
   name: policy-bot  
   environment: production
   
-  image: palantirtechnologies/policy-bot:1.31.0
+  image: 
+    repository: palantirtechnologies/policy-bot
+    tag: 1.31.0
   port: 8080
   
   environmentVariables:

--- a/examples/multiple/values.yaml
+++ b/examples/multiple/values.yaml
@@ -5,7 +5,9 @@ app:
   
   environment: production
   
-  image: path-to-repo/helloworld:v1.2.9999
+  image: 
+    repository: path-to-repo/helloworld
+    tag: v1.2.9999
   port: 3000
   
   environmentVariables:


### PR DESCRIPTION
Looks like helm has a untold convention, [see](https://docs.renovatebot.com/modules/manager/helm-values/#additional-information)
on how images should be defined.

This PR will standardize how we define helm images in values.
This will allow renovate bot to automatically update our
helm values when a new image is published.
