### PR TITLE
fix: validation error due to missing containerPort

### DIFF
--- a/charts/coop-app-chart/templates/deployment.yaml
+++ b/charts/coop-app-chart/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
               protocol: TCP
             {{- if .Values.connectivity.gRPCGateway.enabled }}
             - name: grpc-gateway
-              port: {{ .Values.connectivity.gRPCGateway.portOverride | default (.Values.port | add1f)  }}
+              containerPort: {{ .Values.connectivity.gRPCGateway.portOverride | default (.Values.port | add1f)  }}
               protocol: HTTP
             {{- end }}
           livenessProbe:


### PR DESCRIPTION
The schema use for validation: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/deployment-apps-v1.json#/properties/spec/properties/template/properties/spec/properties/containers/items/properties/ports/items/required
specifies that the port must contain `containerPort` key.

We had a `port` key, which looks like a typo, compared to another
port configuration we have.

https://github.com/coopnorge/helm-base-chart/blob/33c9882b87276fec9cb1c109f00dc92bad28e748/charts/coop-app-chart/templates/deployment.yaml#L83-L85