### PR TITLE
fix: HTTP is not a valid ports.protocol

### DIFF
--- a/charts/coop-app-chart/templates/deployment.yaml
+++ b/charts/coop-app-chart/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
             {{- if .Values.connectivity.gRPCGateway.enabled }}
             - name: grpc-gateway
               containerPort: {{ .Values.connectivity.gRPCGateway.portOverride | default (.Values.port | add1f)  }}
-              protocol: HTTP
+              protocol: TCP
             {{- end }}
           livenessProbe:
             {{- if .Values.health.livenessProbe -}}

--- a/charts/coop-app-chart/templates/service.yaml
+++ b/charts/coop-app-chart/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
     {{- if .Values.connectivity.gRPCGateway.enabled }}
     - name: grpc-gateway
       port: {{ .Values.connectivity.gRPCGateway.portOverride | default (.Values.port | add1f)  }}
-      protocol: HTTP
+      protocol: TCP
     {{- end }}
   selector:
     {{- include "coop-app-chart.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Only valid values are `STCP`, `TCP` and `UDP`.
