### PR TITLE
fix: prefix portname with http

### DIFF
--- a/charts/coop-app-chart/templates/service.yaml
+++ b/charts/coop-app-chart/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
       protocol: TCP
       name: {{ include "coop-app-chart.portName" . }}
     {{- if .Values.connectivity.gRPCGateway.enabled }}
-    - name: grpc-gateway
+    - name: http-grpc-gateway
       port: {{ .Values.connectivity.gRPCGateway.portOverride | default (.Values.port | add1f)  }}
       protocol: TCP
       targetPort: {{ .Values.connectivity.gRPCGateway.portOverride | default (.Values.port | add1f)  }}


### PR DESCRIPTION
Having `grpc-` as prefix for the port name caused the traffic routing to happen as `grpc`
protocol caused by istio explicit protocol selector.

See https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection
for more details.

Prefixing it with `http-` should force the protocol to be `HTTP/1.1`
