### PR TITLE
feat: Add feature to set istio proxy cpu and memory request

### DIFF
--- a/charts/coop-app-chart/templates/deployment.yaml
+++ b/charts/coop-app-chart/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
         sidecar.istio.io/proxyMemory: {{ .Values.resources.istioProxyMemory  | default "64M" }}
+        sidecar.istio.io/proxyCPU: {{ .Values.resources.istioProxyCpu  | default "20m" }}
     spec:
       serviceAccountName: {{ .Values.name }}
       securityContext:

--- a/charts/coop-app-chart/templates/deployment.yaml
+++ b/charts/coop-app-chart/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         {{- include "coop-app-chart.podLabels" . | nindent 8 }}
       annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+        sidecar.istio.io/proxyMemory: {{ .Values.resources.istioProxyMemory  | default "64M" }}
     spec:
       serviceAccountName: {{ .Values.name }}
       securityContext:

--- a/charts/coop-app-chart/values.schema.json
+++ b/charts/coop-app-chart/values.schema.json
@@ -403,6 +403,12 @@
       "title": "resources",
       "description": "The resources that the service requires to run",
       "properties": {
+        "istioProxyCpu": {
+          "type": "string",
+          "title": "memory",
+          "description": "The amount of CPU for the istio sidecar service. ",
+          "default": "20m"
+        },
         "cpu": {
           "title": "cpu",
           "description": "The amount of CPU for this service. 1 = 1 CPU and 500m = 0.5 CPU.",

--- a/charts/coop-app-chart/values.schema.json
+++ b/charts/coop-app-chart/values.schema.json
@@ -416,6 +416,12 @@
             }
           ]
         },
+        "istioProxyMemory": {
+          "type": "string",
+          "title": "memory",
+          "description": "The amount of memory for the istio sidecar service. ",
+          "default": "64M"
+        },
         "memory": {
           "type": "string",
           "title": "memory",

--- a/charts/coop-app-chart/values.yaml
+++ b/charts/coop-app-chart/values.yaml
@@ -130,6 +130,12 @@ scaling:
 # required: false
 # @schema
 resources:
+  # The amount of memory for istio sidecar
+  # @schema
+  # type: string
+  # required: false
+  # @schema
+  istioProxyMemory: 64M
   # The amount of memory for this service. 
   # @schema
   # type: string

--- a/charts/coop-app-chart/values.yaml
+++ b/charts/coop-app-chart/values.yaml
@@ -136,6 +136,12 @@ resources:
   # required: false
   # @schema
   istioProxyMemory: 64M
+  # The amount of CPU for istio sidecar
+  # @schema
+  # type: string
+  # required: false
+  # @schema
+  istioProxyCpu: 20m
   # The amount of memory for this service. 
   # @schema
   # type: string


### PR DESCRIPTION
The default values set here (64Mi and 20m) are quite conservative for services. The median values are close to 48Mi and 10m respectively.

Based on usage in production, following namespaces are the only exceptions:
- idp-test-client
- shopping-list
- store-information

All of the above use kustomize at the moment so it is safe to rollout as a minor version upgrade.
